### PR TITLE
fix: addondeployment downgrade agent namespace feature

### DIFF
--- a/multicluster-resiliency-addon/templates/addondeploymentconfig.yaml
+++ b/multicluster-resiliency-addon/templates/addondeploymentconfig.yaml
@@ -7,7 +7,7 @@ metadata:
   name: {{ .Chart.Name }}-deploy-config
   namespace: {{ .Values.manager.namespace }}
 spec:
-  agentInstallNamespace: {{ .Values.agent.namespace }}
+{{/*  agentInstallNamespace: {{ .Values.agent.namespace }}*/}}
   customizedVariables:
     - name: AgentReplicas
       value: {{ .Values.agent.replicas | quote }}


### PR DESCRIPTION
The AddonDeploymentConfig.Spec.AgentInstallNamespace was introduced in
open-cluster-management.io/api v0.12.0 which is not yet supported by ACM 2.8.x.

Signed-off-by: Tomer Figenblat <tfigenbl@redhat.com>

Addon PR: https://github.com/RHEcosystemAppEng/multicluster-resiliency-addon/pull/9
