### PR TITLE
fix: added update permissions for hive claims

### DIFF
--- a/multicluster-resiliency-addon/templates/clusterrole.yaml
+++ b/multicluster-resiliency-addon/templates/clusterrole.yaml
@@ -148,6 +148,7 @@ rules:
       - create
       - get
       - list
+      - update
       - watch
   - apiGroups:
       - hive.openshift.io


### PR DESCRIPTION
update permissions are required for removing annotations

addon PR: https://github.com/RHEcosystemAppEng/multicluster-resiliency-addon/pull/12

Signed-off-by: Tomer Figenblat <tfigenbl@redhat.com>
