### PR TITLE
fix: managed clusters switched to patch instead of updates

### DIFF
--- a/multicluster-resiliency-addon/templates/clusterrole.yaml
+++ b/multicluster-resiliency-addon/templates/clusterrole.yaml
@@ -123,10 +123,10 @@ rules:
     resources:
       - managedclusters
     verbs:
-      - create
       - delete
       - get
       - list
+      - patch
       - update
       - watch
   - apiGroups:


### PR DESCRIPTION
addon pr: https://github.com/RHEcosystemAppEng/multicluster-resiliency-addon/pull/14/files

Signed-off-by: Tomer Figenblat <tfigenbl@redhat.com>
