### PR TITLE
fix: typo in resilient cluster api status clustar availiability type

### DIFF
--- a/multicluster-resiliency-addon/crds/appeng.ecosystem.redhat.com_resilientclusters.yaml
+++ b/multicluster-resiliency-addon/crds/appeng.ecosystem.redhat.com_resilientclusters.yaml
@@ -49,7 +49,7 @@ spec:
                     at a specific time.
                   properties:
                     availability:
-                      description: ClustarAvailability is a bool representing whether
+                      description: ClusterAvailability is a bool representing whether
                         not the Spoke cluster is available. Use ClusterAvailable and
                         ClusterNotAvailable.
                       enum:
@@ -65,7 +65,7 @@ spec:
                     at a specific time.
                   properties:
                     availability:
-                      description: ClustarAvailability is a bool representing whether
+                      description: ClusterAvailability is a bool representing whether
                         not the Spoke cluster is available. Use ClusterAvailable and
                         ClusterNotAvailable.
                       enum:
@@ -81,7 +81,7 @@ spec:
                     at a specific time.
                   properties:
                     availability:
-                      description: ClustarAvailability is a bool representing whether
+                      description: ClusterAvailability is a bool representing whether
                         not the Spoke cluster is available. Use ClusterAvailable and
                         ClusterNotAvailable.
                       enum:


### PR DESCRIPTION
addon pr: https://github.com/RHEcosystemAppEng/multicluster-resiliency-addon/pull/15

Signed-off-by: Tomer Figenblat <tfigenbl@redhat.com>
