### PR TITLE
fix: added permissions for clustermanagementaddon status patch and update

### DIFF
--- a/multicluster-resiliency-addon/templates/clusterrole.yaml
+++ b/multicluster-resiliency-addon/templates/clusterrole.yaml
@@ -43,6 +43,13 @@ rules:
   - apiGroups:
       - addon.open-cluster-management.io
     resources:
+      - clustermanagementaddons/status
+    verbs:
+      - patch
+      - update
+  - apiGroups:
+      - addon.open-cluster-management.io
+    resources:
       - managedclusteraddons
     verbs:
       - create


### PR DESCRIPTION
commit: https://github.com/RHEcosystemAppEng/multicluster-resiliency-addon/commit/26f8ff58e12d3ad97c9c3be57b8aaa51a24a01f9

Signed-off-by: Tomer Figenblat <tfigenbl@redhat.com>
